### PR TITLE
Add JTest report frontend

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,38 +5,17 @@
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+table {
+  margin: 1em auto;
+  width: 100%;
+  border-collapse: collapse;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+th, td {
+  border: 1px solid #ccc;
+  padding: 0.5em;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+pre {
+  text-align: left;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -16,6 +16,34 @@ th, td {
   padding: 0.5em;
 }
 
+tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.filter-bar {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.file-input {
+  padding: 0.5rem;
+  background-color: #1a1a1a;
+  color: inherit;
+  border-radius: 4px;
+  border: 1px solid #555;
+}
+
+@media (prefers-color-scheme: light) {
+  tr:nth-child(even) {
+    background-color: #f3f3f3;
+  }
+  .file-input {
+    background-color: #fff;
+  }
+}
+
 pre {
   text-align: left;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import JTestReport from './JTestReport'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div>
+      <JTestReport />
+    </div>
   )
 }
 

--- a/src/JTestReport.tsx
+++ b/src/JTestReport.tsx
@@ -1,4 +1,5 @@
-import { useState, ChangeEvent } from 'react'
+import { useState } from 'react'
+import type { ChangeEvent } from 'react'
 
 interface TestResult {
   name: string
@@ -10,9 +11,11 @@ interface JTestResult {
   tests: TestResult[]
 }
 
+type Filter = 'all' | 'passed' | 'failed'
+
 export default function JTestReport() {
   const [tests, setTests] = useState<TestResult[]>([])
-  const [filter, setFilter] = useState<'all' | 'passed' | 'failed'>('all')
+  const [filter, setFilter] = useState<Filter>('all')
   const [openDetails, setOpenDetails] = useState<number | null>(null)
 
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -28,6 +31,7 @@ export default function JTestReport() {
         setTests([])
       }
     } catch (err) {
+      console.error(err)
       alert('Invalid JTest file')
       setTests([])
     }
@@ -39,27 +43,40 @@ export default function JTestReport() {
   })
 
   return (
-    <div>
+    <div className="jtest-report">
       <h1>JTest \u30ec\u30dd\u30fc\u30c8</h1>
-      <input type="file" accept="application/json" onChange={handleFileChange} />
-      {tests.length > 0 && (
-        <div>
+      <div className="filter-bar">
+        <input
+          type="file"
+          accept="application/json"
+          onChange={handleFileChange}
+          className="file-input"
+        />
+        {tests.length > 0 && (
           <label>
             \u30d5\u30a3\u30eb\u30bf\u30fc:
-            <select value={filter} onChange={(e) => setFilter(e.target.value as any)}>
+            <select
+              value={filter}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                setFilter(e.target.value as Filter)
+              }
+            >
               <option value="all">\u3059\u3079\u3066</option>
               <option value="passed">\u6210\u529f</option>
               <option value="failed">\u5931\u6557</option>
             </select>
           </label>
-          <table>
-            <thead>
-              <tr>
-                <th>\u30c6\u30b9\u30c8\u540d</th>
-                <th>\u7d50\u679c</th>
-                <th>\u8a73\u7d30</th>
-              </tr>
-            </thead>
+        )}
+      </div>
+      {tests.length > 0 && (
+        <table className="test-table">
+          <thead>
+            <tr>
+              <th>\u30c6\u30b9\u30c8\u540d</th>
+              <th>\u7d50\u679c</th>
+              <th>\u8a73\u7d30</th>
+            </tr>
+          </thead>
             <tbody>
               {filteredTests.map((test: TestResult, idx: number) => (
                 <tr key={idx}>
@@ -75,7 +92,6 @@ export default function JTestReport() {
               ))}
             </tbody>
           </table>
-        </div>
       )}
     </div>
   )

--- a/src/JTestReport.tsx
+++ b/src/JTestReport.tsx
@@ -1,0 +1,82 @@
+import { useState, ChangeEvent } from 'react'
+
+interface TestResult {
+  name: string
+  status: string
+  details?: string
+}
+
+interface JTestResult {
+  tests: TestResult[]
+}
+
+export default function JTestReport() {
+  const [tests, setTests] = useState<TestResult[]>([])
+  const [filter, setFilter] = useState<'all' | 'passed' | 'failed'>('all')
+  const [openDetails, setOpenDetails] = useState<number | null>(null)
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      const text = await file.text()
+      const data = JSON.parse(text) as JTestResult
+      if (Array.isArray(data.tests)) {
+        setTests(data.tests)
+      } else {
+        alert('Invalid JTest file')
+        setTests([])
+      }
+    } catch (err) {
+      alert('Invalid JTest file')
+      setTests([])
+    }
+  }
+
+  const filteredTests = tests.filter((t: TestResult) => {
+    if (filter === 'all') return true
+    return filter === 'passed' ? t.status === 'passed' : t.status === 'failed'
+  })
+
+  return (
+    <div>
+      <h1>JTest \u30ec\u30dd\u30fc\u30c8</h1>
+      <input type="file" accept="application/json" onChange={handleFileChange} />
+      {tests.length > 0 && (
+        <div>
+          <label>
+            \u30d5\u30a3\u30eb\u30bf\u30fc:
+            <select value={filter} onChange={(e) => setFilter(e.target.value as any)}>
+              <option value="all">\u3059\u3079\u3066</option>
+              <option value="passed">\u6210\u529f</option>
+              <option value="failed">\u5931\u6557</option>
+            </select>
+          </label>
+          <table>
+            <thead>
+              <tr>
+                <th>\u30c6\u30b9\u30c8\u540d</th>
+                <th>\u7d50\u679c</th>
+                <th>\u8a73\u7d30</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTests.map((test: TestResult, idx: number) => (
+                <tr key={idx}>
+                  <td>{test.name}</td>
+                  <td>{test.status}</td>
+                  <td>
+                    <button onClick={() => setOpenDetails(openDetails === idx ? null : idx)}>
+                      {openDetails === idx ? '\u975e\u8868\u793a' : '\u8868\u793a'}
+                    </button>
+                    {openDetails === idx && <pre>{test.details || ''}</pre>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- build a JTest report page that loads a JSON result file
- display tests with basic filtering and detail toggle
- wire JTestReport component into the app
- add simple table styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing React/Vite type dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cc03f3e748329941119399a05d931