### PR TITLE
playwright junit 対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwindcss": "^4.1.10"
+    "tailwindcss": "^4.1.10",
+    "fast-xml-parser": "^4.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
@@ -26,6 +28,7 @@
     "globals": "^16.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/JTestReport.tsx
+++ b/src/JTestReport.tsx
@@ -1,19 +1,15 @@
 import { useState } from 'react'
 import type { ChangeEvent } from 'react'
+import type { TestResult } from '@/parsePlaywrightJUnit'
+import { parsePlaywrightJUnit } from '@/parsePlaywrightJUnit'
 
-interface TestResult {
-  name: string
-  status: string
-  details?: string
-}
-
-interface JTestResult {
+interface JUnitResult {
   tests: TestResult[]
 }
 
 type Filter = 'all' | 'passed' | 'failed'
 
-// JTest の結果を表示するコンポーネント
+// JUnit の結果を表示するコンポーネント
 export default function JTestReport() {
   const [tests, setTests] = useState<TestResult[]>([])
   const [filter, setFilter] = useState<Filter>('all')
@@ -24,16 +20,11 @@ export default function JTestReport() {
     if (!file) return
     try {
       const text = await file.text()
-      const data = JSON.parse(text) as JTestResult
-      if (Array.isArray(data.tests)) {
-        setTests(data.tests)
-      } else {
-        alert('Invalid JTest file')
-        setTests([])
-      }
+      const result = parsePlaywrightJUnit(text) as JUnitResult
+      setTests(result.tests)
     } catch (err) {
       console.error(err)
-      alert('Invalid JTest file')
+      alert('Invalid JUnit file')
       setTests([])
     }
   }
@@ -45,11 +36,11 @@ export default function JTestReport() {
 
   return (
     <div>
-      <h1 className="text-3xl font-bold mb-4">JTest レポート</h1>
+      <h1 className="text-3xl font-bold mb-4">JUnit レポート</h1>
       <div className="flex justify-center gap-4 mb-4">
         <input
           type="file"
-          accept="application/json"
+          accept="application/xml"
           onChange={handleFileChange}
           className="p-2 bg-neutral-900 border border-gray-600 rounded"
         />

--- a/src/JTestReport.tsx
+++ b/src/JTestReport.tsx
@@ -1,11 +1,7 @@
 import { useState } from 'react'
 import type { ChangeEvent } from 'react'
-import type { TestResult } from '@/parsePlaywrightJUnit'
+import type { TestResult, JUnitResult } from '@/parsePlaywrightJUnit'
 import { parsePlaywrightJUnit } from '@/parsePlaywrightJUnit'
-
-interface JUnitResult {
-  tests: TestResult[]
-}
 
 type Filter = 'all' | 'passed' | 'failed'
 

--- a/src/parsePlaywrightJUnit.ts
+++ b/src/parsePlaywrightJUnit.ts
@@ -1,0 +1,58 @@
+import { XMLParser } from 'fast-xml-parser'
+
+export interface TestResult {
+  name: string
+  status: string
+  details?: string
+}
+
+export interface JUnitResult {
+  tests: TestResult[]
+}
+
+/**
+ * Playwright の JUnit XML を解析してテスト結果を返す
+ */
+export function parsePlaywrightJUnit(xmlText: string): JUnitResult {
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' })
+  const root = parser.parse(xmlText)
+
+  const suites: any[] = []
+  if (root.testsuites) {
+    const ts = root.testsuites.testsuite
+    if (Array.isArray(ts)) suites.push(...ts)
+    else if (ts) suites.push(ts)
+  }
+  if (root.testsuite) {
+    const ts = root.testsuite
+    if (Array.isArray(ts)) suites.push(...ts)
+    else suites.push(ts)
+  }
+
+  const cases: any[] = []
+  for (const suite of suites) {
+    if (!suite) continue
+    const tcs = suite.testcase
+    if (Array.isArray(tcs)) cases.push(...tcs)
+    else if (tcs) cases.push(tcs)
+  }
+
+  const tests = cases.map(tc => {
+    const details = tc.failure
+    let text: string | undefined
+    if (details) {
+      if (typeof details === 'string') {
+        text = details
+      } else if (typeof details === 'object') {
+        text = details['#text'] || details['message'] || details['@_message']
+      }
+    }
+    return {
+      name: tc.name,
+      status: details ? 'failed' : 'passed',
+      details: text
+    }
+  })
+
+  return { tests }
+}

--- a/tests/parsePlaywrightJUnit.test.ts
+++ b/tests/parsePlaywrightJUnit.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs'
+import { parsePlaywrightJUnit } from '@/parsePlaywrightJUnit'
+import { expect, test } from 'vitest'
+
+// サンプル XML を読み込みパースできるか確認する
+const xml = readFileSync('tests/sample-junit.xml', 'utf-8')
+const result = parsePlaywrightJUnit(xml)
+
+test('XML を正しく読み込める', () => {
+  expect(result.tests.length).toBe(2)
+  const [pass, fail] = result.tests
+  expect(pass.status).toBe('passed')
+  expect(pass.name).toBe('test success')
+  expect(fail.status).toBe('failed')
+  expect(fail.details).toContain('Assertion error')
+})

--- a/tests/sample-junit.xml
+++ b/tests/sample-junit.xml
@@ -1,0 +1,8 @@
+<testsuites>
+  <testsuite name="suite1" tests="2" failures="1">
+    <testcase name="test success" classname="a" time="0.1" />
+    <testcase name="test failure" classname="a" time="0.2">
+      <failure message="Error">Assertion error</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- playwright の junit XML を解析する `parsePlaywrightJUnit` を追加
- JTestReport コンポーネントで JUnit レポートを表示
- JUnit サンプルを使った単体テストを作成
- vitest の設定とテストスクリプトを追加

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/vitest: Forbidden)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7565f54883299ee1d5104a5be970