### PR TITLE
feat: update junit samples for multiple reports

### DIFF
--- a/src/JTestReport.tsx
+++ b/src/JTestReport.tsx
@@ -2,92 +2,178 @@ import { useState } from 'react'
 import type { ChangeEvent } from 'react'
 import type { TestResult, JUnitResult } from '@/parsePlaywrightJUnit'
 import { parsePlaywrightJUnit } from '@/parsePlaywrightJUnit'
+import {
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts'
+
+/**
+ * 単一のテストファイルから得られた情報
+ */
+interface Report {
+  name: string
+  tests: TestResult[]
+}
 
 type Filter = 'all' | 'passed' | 'failed'
 
-// JUnit の結果を表示するコンポーネント
+/**
+ * JUnit XML を複数読み込み表示するコンポーネント
+ */
 export default function JTestReport() {
-  const [tests, setTests] = useState<TestResult[]>([])
+  const [reports, setReports] = useState<Report[]>([])
+  const [selectedReport, setSelectedReport] = useState<number | null>(null)
+  const [selectedTest, setSelectedTest] = useState<number | null>(null)
   const [filter, setFilter] = useState<Filter>('all')
-  const [openDetails, setOpenDetails] = useState<number | null>(null)
 
+  /**
+   * ファイル選択時に複数 XML を読み込み配列に追加する
+   */
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    try {
-      const text = await file.text()
-      const result = parsePlaywrightJUnit(text) as JUnitResult
-      setTests(result.tests)
-    } catch (err) {
-      console.error(err)
-      alert('Invalid JUnit file')
-      setTests([])
+    const files = e.target.files
+    if (!files) return
+
+    const loaded: Report[] = []
+    for (const file of Array.from(files)) {
+      try {
+        const text = await file.text()
+        const result = parsePlaywrightJUnit(text) as JUnitResult
+        loaded.push({ name: file.name, tests: result.tests })
+      } catch (err) {
+        console.error(err)
+        alert(`Invalid JUnit file: ${file.name}`)
+      }
     }
+    if (loaded.length > 0) {
+      setReports(prev => [...prev, ...loaded])
+      if (selectedReport === null) setSelectedReport(0)
+    }
+    e.target.value = ''
   }
 
-  const filteredTests = tests.filter((t: TestResult) => {
+  const currentTests =
+    selectedReport !== null ? reports[selectedReport].tests : []
+
+  const filteredTests = currentTests.filter(t => {
     if (filter === 'all') return true
     return filter === 'passed' ? t.status === 'passed' : t.status === 'failed'
+  })
+
+  const chartData = reports.map((r, idx) => {
+    let passed = 0
+    let failed = 0
+    r.tests.forEach(t => {
+      if (t.status === 'passed') passed += 1
+      else if (t.status === 'failed') failed += 1
+    })
+    return { name: `#${idx + 1}`, passed, failed }
   })
 
   return (
     <div>
       <h1 className="text-3xl font-bold mb-4">JUnit レポート</h1>
-      <div className="flex justify-center gap-4 mb-4">
-        <input
-          type="file"
-          accept="application/xml"
-          onChange={handleFileChange}
-          className="p-2 bg-neutral-900 border border-gray-600 rounded"
-        />
-        {tests.length > 0 && (
-          <label>
-            フィルター:
-            <select
-              value={filter}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                setFilter(e.target.value as Filter)
-              }
-            >
-              <option value="all">すべて</option>
-              <option value="passed">成功</option>
-              <option value="failed">失敗</option>
-            </select>
-          </label>
-        )}
-      </div>
-      {tests.length > 0 && (
-        <table className="mx-auto w-full border-collapse">
-          <thead>
-            <tr>
-              <th className="border p-2">テスト名</th>
-              <th className="border p-2">結果</th>
-              <th className="border p-2">詳細</th>
-            </tr>
-          </thead>
-            <tbody>
-              {filteredTests.map((test: TestResult, idx: number) => (
-                <tr key={idx} className="even:bg-gray-50 dark:even:bg-white/5">
-                  <td className="border p-2">{test.name}</td>
-                  <td className="border p-2">{test.status}</td>
-                  <td className="border p-2">
-                    <button
-                      className="px-2 py-1 rounded bg-gray-700 text-white hover:bg-gray-600"
-                      onClick={() =>
-                        setOpenDetails(openDetails === idx ? null : idx)
-                      }
-                    >
-                      {openDetails === idx ? '非表示' : '表示'}
-                    </button>
-                    {openDetails === idx && (
-                      <pre className="text-left mt-2">{test.details || ''}</pre>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      {reports.length > 0 && (
+        <div className="w-full h-48 mb-4">
+          <ResponsiveContainer>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" />
+              <YAxis allowDecimals={false} />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="passed" fill="#4ade80" name="成功" />
+              <Bar dataKey="failed" fill="#f87171" name="失敗" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
       )}
+      <div className="flex gap-4">
+        <aside className="w-1/4 space-y-2">
+          <input
+            type="file"
+            multiple
+            accept="application/xml"
+            onChange={handleFileChange}
+            className="w-full p-2 bg-neutral-900 border border-gray-600 rounded"
+          />
+          <ul className="space-y-1">
+            {reports.map((r, idx) => (
+              <li key={idx}>
+                <button
+                  onClick={() => {
+                    setSelectedReport(idx)
+                    setSelectedTest(null)
+                  }}
+                  className={`w-full text-left px-2 py-1 rounded ${
+                    selectedReport === idx
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-200 dark:bg-gray-700'
+                  }`}
+                >
+                  {r.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+        <main className="w-2/4 overflow-auto">
+          {currentTests.length > 0 && (
+            <>
+              <div className="mb-2">
+                <label>
+                  フィルター:
+                  <select
+                    value={filter}
+                    onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                      setFilter(e.target.value as Filter)
+                    }
+                    className="ml-1 border rounded"
+                  >
+                    <option value="all">すべて</option>
+                    <option value="passed">成功</option>
+                    <option value="failed">失敗</option>
+                  </select>
+                </label>
+              </div>
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th className="border p-2">テスト名</th>
+                    <th className="border p-2">結果</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredTests.map((test, idx) => (
+                    <tr
+                      key={idx}
+                      className={`cursor-pointer even:bg-gray-50 dark:even:bg-white/5 ${
+                        selectedTest === idx ? 'bg-blue-100 dark:bg-blue-900' : ''
+                      }`}
+                      onClick={() => setSelectedTest(idx)}
+                    >
+                      <td className="border p-2">{test.name}</td>
+                      <td className="border p-2">{test.status}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+        </main>
+        <div className="w-1/4">
+          {selectedTest !== null && filteredTests[selectedTest] && (
+            <pre className="whitespace-pre-wrap border p-2 rounded bg-gray-50 dark:bg-gray-800">
+              {filteredTests[selectedTest].details || '詳細なし'}
+            </pre>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/parsePlaywrightJUnit.ts
+++ b/src/parsePlaywrightJUnit.ts
@@ -17,7 +17,7 @@ export function parsePlaywrightJUnit(xmlText: string): JUnitResult {
   const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' })
   const root = parser.parse(xmlText)
 
-  const suites: any[] = []
+  const suites: Record<string, unknown>[] = []
   if (root.testsuites) {
     const ts = root.testsuites.testsuite
     if (Array.isArray(ts)) suites.push(...ts)
@@ -29,7 +29,7 @@ export function parsePlaywrightJUnit(xmlText: string): JUnitResult {
     else suites.push(ts)
   }
 
-  const cases: any[] = []
+  const cases: Record<string, unknown>[] = []
   for (const suite of suites) {
     if (!suite) continue
     const tcs = suite.testcase

--- a/tests/parsePlaywrightJUnit.test.ts
+++ b/tests/parsePlaywrightJUnit.test.ts
@@ -2,15 +2,37 @@ import { readFileSync } from 'fs'
 import { parsePlaywrightJUnit } from '@/parsePlaywrightJUnit'
 import { expect, test } from 'vitest'
 
-// サンプル XML を読み込みパースできるか確認する
-const xml = readFileSync('tests/sample-junit.xml', 'utf-8')
-const result = parsePlaywrightJUnit(xml)
+// 複数の JUnit XML を読み込みパース結果を検証する
+const xml1 = readFileSync('tests/sample-junit1.xml', 'utf-8')
+const xml2 = readFileSync('tests/sample-junit2.xml', 'utf-8')
+const xml3 = readFileSync('tests/sample-junit3.xml', 'utf-8')
 
-test('XML を正しく読み込める', () => {
-  expect(result.tests.length).toBe(2)
-  const [pass, fail] = result.tests
-  expect(pass.status).toBe('passed')
-  expect(pass.name).toBe('test success')
-  expect(fail.status).toBe('failed')
-  expect(fail.details).toContain('Assertion error')
+const result1 = parsePlaywrightJUnit(xml1)
+const result2 = parsePlaywrightJUnit(xml2)
+const result3 = parsePlaywrightJUnit(xml3)
+
+test('1つ目の XML を正しく読み込める', () => {
+  expect(result1.tests.length).toBe(10)
+  const failed = result1.tests.filter(t => t.status === 'failed')
+  expect(failed.length).toBe(3)
+  const addItem = result1.tests.find(t => t.name === 'add item')
+  expect(addItem?.status).toBe('failed')
+})
+
+test('後続の XML でテストが増え失敗が解消される', () => {
+  expect(result2.tests.length).toBeGreaterThan(result1.tests.length)
+  expect(result3.tests.length).toBeGreaterThan(result2.tests.length)
+
+  const addItem2 = result2.tests.find(t => t.name === 'add item')
+  const deleteUser2 = result2.tests.find(t => t.name === 'delete user')
+  expect(addItem2?.status).toBe('passed')
+  expect(deleteUser2?.status).toBe('passed')
+
+  const addItem3 = result3.tests.find(t => t.name === 'add item')
+  const deleteUser3 = result3.tests.find(t => t.name === 'delete user')
+  expect(addItem3?.status).toBe('passed')
+  expect(deleteUser3?.status).toBe('passed')
+
+  const allPassed3 = result3.tests.every(t => t.status === 'passed')
+  expect(allPassed3).toBe(true)
 })

--- a/tests/sample-junit.xml
+++ b/tests/sample-junit.xml
@@ -1,8 +1,0 @@
-<testsuites>
-  <testsuite name="suite1" tests="2" failures="1">
-    <testcase name="test success" classname="a" time="0.1" />
-    <testcase name="test failure" classname="a" time="0.2">
-      <failure message="Error">Assertion error</failure>
-    </testcase>
-  </testsuite>
-</testsuites>

--- a/tests/sample-junit1.xml
+++ b/tests/sample-junit1.xml
@@ -1,0 +1,22 @@
+<testsuites>
+  <testsuite name="chromium" tests="5" failures="2">
+    <testcase name="login success" classname="chromium" time="0.1" />
+    <testcase name="logout success" classname="chromium" time="0.1" />
+    <testcase name="add item" classname="chromium" time="0.2">
+      <failure message="AssertionError">item not added</failure>
+    </testcase>
+    <testcase name="view dashboard" classname="chromium" time="0.1" />
+    <testcase name="delete user" classname="chromium" time="0.1">
+      <failure message="AssertionError">cannot delete user</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="firefox" tests="5" failures="1">
+    <testcase name="login success" classname="firefox" time="0.1" />
+    <testcase name="logout success" classname="firefox" time="0.1" />
+    <testcase name="add item" classname="firefox" time="0.2">
+      <failure message="AssertionError">item not added</failure>
+    </testcase>
+    <testcase name="update profile" classname="firefox" time="0.1" />
+    <testcase name="remove item" classname="firefox" time="0.1" />
+  </testsuite>
+</testsuites>

--- a/tests/sample-junit2.xml
+++ b/tests/sample-junit2.xml
@@ -1,0 +1,20 @@
+<testsuites>
+  <testsuite name="chromium" tests="7" failures="0">
+    <testcase name="login success" classname="chromium" time="0.1" />
+    <testcase name="logout success" classname="chromium" time="0.1" />
+    <testcase name="add item" classname="chromium" time="0.2" />
+    <testcase name="view dashboard" classname="chromium" time="0.1" />
+    <testcase name="delete user" classname="chromium" time="0.1" />
+    <testcase name="search item" classname="chromium" time="0.2" />
+    <testcase name="bulk update" classname="chromium" time="0.3" />
+  </testsuite>
+  <testsuite name="firefox" tests="7" failures="0">
+    <testcase name="login success" classname="firefox" time="0.1" />
+    <testcase name="logout success" classname="firefox" time="0.1" />
+    <testcase name="add item" classname="firefox" time="0.2" />
+    <testcase name="update profile" classname="firefox" time="0.1" />
+    <testcase name="remove item" classname="firefox" time="0.1" />
+    <testcase name="search item" classname="firefox" time="0.2" />
+    <testcase name="bulk update" classname="firefox" time="0.3" />
+  </testsuite>
+</testsuites>

--- a/tests/sample-junit3.xml
+++ b/tests/sample-junit3.xml
@@ -1,0 +1,26 @@
+<testsuites>
+  <testsuite name="chromium" tests="10" failures="0">
+    <testcase name="login success" classname="chromium" time="0.1" />
+    <testcase name="logout success" classname="chromium" time="0.1" />
+    <testcase name="add item" classname="chromium" time="0.2" />
+    <testcase name="view dashboard" classname="chromium" time="0.1" />
+    <testcase name="delete user" classname="chromium" time="0.1" />
+    <testcase name="search item" classname="chromium" time="0.2" />
+    <testcase name="bulk update" classname="chromium" time="0.3" />
+    <testcase name="export data" classname="chromium" time="0.2" />
+    <testcase name="import data" classname="chromium" time="0.2" />
+    <testcase name="settings page" classname="chromium" time="0.2" />
+  </testsuite>
+  <testsuite name="firefox" tests="10" failures="0">
+    <testcase name="login success" classname="firefox" time="0.1" />
+    <testcase name="logout success" classname="firefox" time="0.1" />
+    <testcase name="add item" classname="firefox" time="0.2" />
+    <testcase name="update profile" classname="firefox" time="0.1" />
+    <testcase name="remove item" classname="firefox" time="0.1" />
+    <testcase name="search item" classname="firefox" time="0.2" />
+    <testcase name="bulk update" classname="firefox" time="0.3" />
+    <testcase name="export data" classname="firefox" time="0.2" />
+    <testcase name="import data" classname="firefox" time="0.2" />
+    <testcase name="settings page" classname="firefox" time="0.2" />
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## Summary
- JUnit サンプル XML を3ファイルに増やしテストケースを大幅追加
- 失敗していたケースが後続ファイルで成功する流れをテストに追加
- 既存テストをマルチレポート用に更新

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_684d7fc2bbb483299eeed18d0503fd1b