### PR TITLE
feat: add modern UI components and layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,15 @@ import JTestReport from '@/JTestReport'
 // アプリケーション全体を構成するコンポーネント
 function App() {
   return (
-    <div className="max-w-[1280px] p-8 mx-auto text-center">
-      <JTestReport />
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-blue-600 text-white p-4 text-xl text-center font-bold">
+        JUnit ビューア
+      </header>
+      <main className="flex-1 p-8">
+        <div className="max-w-[1280px] mx-auto">
+          <JTestReport />
+        </div>
+      </main>
     </div>
   )
 }

--- a/src/JTestReport.tsx
+++ b/src/JTestReport.tsx
@@ -2,6 +2,10 @@ import { useState } from 'react'
 import type { ChangeEvent } from 'react'
 import type { TestResult, JUnitResult } from '@/parsePlaywrightJUnit'
 import { parsePlaywrightJUnit } from '@/parsePlaywrightJUnit'
+import ModernButton from '@/components/ModernButton'
+import ModernInputFile from '@/components/ModernInputFile'
+import ModernSelect from '@/components/ModernSelect'
+import ModernTable from '@/components/ModernTable'
 import {
   BarChart,
   Bar,
@@ -93,76 +97,54 @@ export default function JTestReport() {
           </ResponsiveContainer>
         </div>
       )}
-      <div className="flex gap-4">
-        <aside className="w-1/4 space-y-2">
-          <input
-            type="file"
+      <div className="flex gap-6">
+        <aside className="w-1/4 space-y-4">
+          <ModernInputFile
             multiple
             accept="application/xml"
             onChange={handleFileChange}
-            className="w-full p-2 bg-neutral-900 border border-gray-600 rounded"
           />
-          <ul className="space-y-1">
+          <ul className="space-y-2">
             {reports.map((r, idx) => (
               <li key={idx}>
-                <button
+                <ModernButton
+                  className={`w-full text-left ${selectedReport === idx ? 'bg-blue-600' : ''}`}
                   onClick={() => {
                     setSelectedReport(idx)
                     setSelectedTest(null)
                   }}
-                  className={`w-full text-left px-2 py-1 rounded ${
-                    selectedReport === idx
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-200 dark:bg-gray-700'
-                  }`}
                 >
                   {r.name}
-                </button>
+                </ModernButton>
               </li>
             ))}
           </ul>
         </aside>
-        <main className="w-2/4 overflow-auto">
+        <main className="w-2/4 space-y-2 overflow-auto">
           {currentTests.length > 0 && (
             <>
-              <div className="mb-2">
-                <label>
-                  フィルター:
-                  <select
-                    value={filter}
-                    onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                      setFilter(e.target.value as Filter)
-                    }
-                    className="ml-1 border rounded"
-                  >
-                    <option value="all">すべて</option>
-                    <option value="passed">成功</option>
-                    <option value="failed">失敗</option>
-                  </select>
-                </label>
+              <div>
+                <label className="mr-2">フィルター:</label>
+                <ModernSelect
+                  value={filter}
+                  onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                    setFilter(e.target.value as Filter)
+                  }
+                >
+                  <option value="all">すべて</option>
+                  <option value="passed">成功</option>
+                  <option value="failed">失敗</option>
+                </ModernSelect>
               </div>
-              <table className="w-full border-collapse">
-                <thead>
-                  <tr>
-                    <th className="border p-2">テスト名</th>
-                    <th className="border p-2">結果</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredTests.map((test, idx) => (
-                    <tr
-                      key={idx}
-                      className={`cursor-pointer even:bg-gray-50 dark:even:bg-white/5 ${
-                        selectedTest === idx ? 'bg-blue-100 dark:bg-blue-900' : ''
-                      }`}
-                      onClick={() => setSelectedTest(idx)}
-                    >
-                      <td className="border p-2">{test.name}</td>
-                      <td className="border p-2">{test.status}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <ModernTable
+                columns={[
+                  { key: 'name', header: 'テスト名' },
+                  { key: 'status', header: '結果' }
+                ]}
+                data={filteredTests.map(t => ({ name: t.name, status: t.status }))}
+                selectedIndex={selectedTest}
+                onRowClick={idx => setSelectedTest(idx)}
+              />
             </>
           )}
         </main>

--- a/src/components/ModernButton.tsx
+++ b/src/components/ModernButton.tsx
@@ -1,0 +1,13 @@
+import type { ButtonHTMLAttributes } from 'react'
+
+/**
+ * モダンなボタンコンポーネント
+ */
+export default function ModernButton({ className = '', ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...props}
+      className={`px-3 py-2 rounded bg-blue-500 text-white hover:bg-blue-600 active:scale-95 transition-transform ${className}`}
+    />
+  )
+}

--- a/src/components/ModernInputFile.tsx
+++ b/src/components/ModernInputFile.tsx
@@ -1,0 +1,14 @@
+import type { InputHTMLAttributes } from 'react'
+
+/**
+ * モダンなファイル選択コンポーネント
+ */
+export default function ModernInputFile({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      type="file"
+      className={`w-full rounded border border-gray-300 px-3 py-2 text-gray-700 file:mr-3 file:rounded file:border-0 file:bg-blue-500 file:px-4 file:py-2 file:text-white hover:file:bg-blue-600 transition-colors ${className}`}
+    />
+  )
+}

--- a/src/components/ModernSelect.tsx
+++ b/src/components/ModernSelect.tsx
@@ -1,0 +1,13 @@
+import type { SelectHTMLAttributes } from 'react'
+
+/**
+ * モダンなセレクトボックス
+ */
+export default function ModernSelect({ className = '', ...props }: SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select
+      {...props}
+      className={`rounded border border-gray-300 px-3 py-2 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition ${className}`}
+    />
+  )
+}

--- a/src/components/ModernTable.tsx
+++ b/src/components/ModernTable.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react'
+
+/** 行データの型 */
+export interface ModernTableRow {
+  [key: string]: ReactNode
+}
+
+interface Column {
+  key: string
+  header: string
+}
+
+interface Props {
+  columns: Column[]
+  data: ModernTableRow[]
+  selectedIndex?: number | null
+  onRowClick?: (index: number) => void
+}
+
+/**
+ * モダンな表コンポーネント
+ */
+export default function ModernTable({ columns, data, selectedIndex = null, onRowClick }: Props) {
+  return (
+    <table className="w-full border-collapse">
+      <thead>
+        <tr>
+          {columns.map(col => (
+            <th key={col.key} className="border p-2 bg-gray-100 text-left">
+              {col.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, idx) => (
+          <tr
+            key={idx}
+            className={`cursor-pointer even:bg-gray-50 hover:bg-blue-50 ${selectedIndex === idx ? 'bg-blue-100' : ''}`}
+            onClick={() => onRowClick && onRowClick(idx)}
+          >
+            {columns.map(col => (
+              <td key={col.key} className="border p-2">
+                {row[col.key]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}


### PR DESCRIPTION
## Summary
- モダンなボタン、ファイル選択、テーブル、セレクトボックスを実装
- JTestReport にこれらのパーツを適用し、レイアウトを整理
- App にヘッダーを追加して画面全体の構成を変更

## Testing
- `pnpm lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684d90aa6f588329b741cd638980cc55