### PR TITLE
feat: enhance junit parser and details

### DIFF
--- a/src/JTestReport.tsx
+++ b/src/JTestReport.tsx
@@ -66,7 +66,9 @@ export default function JTestReport() {
 
   const filteredTests = currentTests.filter(t => {
     if (filter === 'all') return true
-    return filter === 'passed' ? t.status === 'passed' : t.status === 'failed'
+    return filter === 'passed'
+      ? t.status === 'passed'
+      : t.status === 'failed' || t.status === 'error'
   })
 
   const chartData = reports.map((r, idx) => {
@@ -74,7 +76,7 @@ export default function JTestReport() {
     let failed = 0
     r.tests.forEach(t => {
       if (t.status === 'passed') passed += 1
-      else if (t.status === 'failed') failed += 1
+      else if (t.status === 'failed' || t.status === 'error') failed += 1
     })
     return { name: `#${idx + 1}`, passed, failed }
   })
@@ -151,9 +153,69 @@ export default function JTestReport() {
         </main>
         <div className="w-full lg:w-1/4">
           {selectedTest !== null && filteredTests[selectedTest] && (
-            <pre className="whitespace-pre-wrap border p-2 rounded bg-gray-50 dark:bg-gray-800">
-              {filteredTests[selectedTest].details || '詳細なし'}
-            </pre>
+            <div className="space-y-2 border p-2 rounded bg-gray-50 dark:bg-gray-800">
+              <p>
+                <strong>結果:</strong> {filteredTests[selectedTest].status}
+              </p>
+              {filteredTests[selectedTest].classname && (
+                <p>
+                  <strong>クラス:</strong> {filteredTests[selectedTest].classname}
+                </p>
+              )}
+              {filteredTests[selectedTest].file && (
+                <p>
+                  <strong>ファイル:</strong> {filteredTests[selectedTest].file}
+                  {filteredTests[selectedTest].line !== undefined && `:${filteredTests[selectedTest].line}`}
+                </p>
+              )}
+              {filteredTests[selectedTest].time !== undefined && (
+                <p>
+                  <strong>時間:</strong> {filteredTests[selectedTest].time}s
+                </p>
+              )}
+              {filteredTests[selectedTest].assertions !== undefined && (
+                <p>
+                  <strong>アサーション:</strong> {filteredTests[selectedTest].assertions}
+                </p>
+              )}
+              {filteredTests[selectedTest].message && (
+                <p>
+                  <strong>メッセージ:</strong> {filteredTests[selectedTest].message}
+                </p>
+              )}
+              {filteredTests[selectedTest].type && (
+                <p>
+                  <strong>タイプ:</strong> {filteredTests[selectedTest].type}
+                </p>
+              )}
+              {filteredTests[selectedTest].details && (
+                <pre className="whitespace-pre-wrap">
+                  {filteredTests[selectedTest].details}
+                </pre>
+              )}
+              {filteredTests[selectedTest].systemOut && (
+                <pre className="whitespace-pre-wrap">
+                  stdout: {filteredTests[selectedTest].systemOut}
+                </pre>
+              )}
+              {filteredTests[selectedTest].systemErr && (
+                <pre className="whitespace-pre-wrap">
+                  stderr: {filteredTests[selectedTest].systemErr}
+                </pre>
+              )}
+              {filteredTests[selectedTest].properties && (
+                <div>
+                  <strong>プロパティ:</strong>
+                  <ul className="ml-4 list-disc">
+                    {Object.entries(filteredTests[selectedTest].properties!).map(([k, v]) => (
+                      <li key={k}>
+                        {k}: {v}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/tests/parsePlaywrightJUnit.test.ts
+++ b/tests/parsePlaywrightJUnit.test.ts
@@ -6,10 +6,12 @@ import { expect, test } from 'vitest'
 const xml1 = readFileSync('tests/sample-junit1.xml', 'utf-8')
 const xml2 = readFileSync('tests/sample-junit2.xml', 'utf-8')
 const xml3 = readFileSync('tests/sample-junit3.xml', 'utf-8')
+const xmlFull = readFileSync('tests/sample-junit-full.xml', 'utf-8')
 
 const result1 = parsePlaywrightJUnit(xml1)
 const result2 = parsePlaywrightJUnit(xml2)
 const result3 = parsePlaywrightJUnit(xml3)
+const resultFull = parsePlaywrightJUnit(xmlFull)
 
 test('1つ目の XML を正しく読み込める', () => {
   expect(result1.tests.length).toBe(10)
@@ -35,4 +37,18 @@ test('後続の XML でテストが増え失敗が解消される', () => {
 
   const allPassed3 = result3.tests.every(t => t.status === 'passed')
   expect(allPassed3).toBe(true)
+})
+
+test('複雑な XML を正しく解析できる', () => {
+  const tc4 = resultFull.tests.find(t => t.name === 'testCase4')
+  expect(tc4?.status).toBe('skipped')
+  expect(tc4?.message).toBe('Test was skipped.')
+  const tc5 = resultFull.tests.find(t => t.name === 'testCase5')
+  expect(tc5?.status).toBe('failed')
+  expect(tc5?.message).toBe('Expected value did not match.')
+  const tc6 = resultFull.tests.find(t => t.name === 'testCase6')
+  expect(tc6?.status).toBe('error')
+  expect(tc6?.message).toBe('Division by zero.')
+  const tc7 = resultFull.tests.find(t => t.name === 'testCase7')
+  expect(tc7?.systemOut).toBe('Data written to standard out.')
 })

--- a/tests/sample-junit-full.xml
+++ b/tests/sample-junit-full.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Test run" tests="8" failures="1" errors="1" skipped="1" assertions="20" time="16.082687" timestamp="2021-04-02T15:48:23">
+  <testsuite name="Tests.Registration" tests="8" failures="1" errors="1" skipped="1" assertions="20" time="16.082687" timestamp="2021-04-02T15:48:23" file="tests/registration.code">
+    <properties>
+      <property name="version" value="1.774" />
+      <property name="commit" value="ef7bebf" />
+      <property name="browser" value="Google Chrome" />
+      <property name="ci" value="https://github.com/actions/runs/1234" />
+      <property name="config">
+        Config line #1
+        Config line #2
+        Config line #3
+      </property>
+    </properties>
+    <system-out>Data written to standard out.</system-out>
+    <system-err>Data written to standard error.</system-err>
+    <testcase name="testCase1" classname="Tests.Registration" assertions="2" time="2.436" file="tests/registration.code" line="24" />
+    <testcase name="testCase2" classname="Tests.Registration" assertions="6" time="1.534" file="tests/registration.code" line="62" />
+    <testcase name="testCase3" classname="Tests.Registration" assertions="3" time="0.822" file="tests/registration.code" line="102" />
+    <testcase name="testCase4" classname="Tests.Registration" assertions="0" time="0" file="tests/registration.code" line="164">
+      <skipped message="Test was skipped." />
+    </testcase>
+    <testcase name="testCase5" classname="Tests.Registration" assertions="2" time="2.902412" file="tests/registration.code" line="202">
+      <failure message="Expected value did not match." type="AssertionError">
+      </failure>
+    </testcase>
+    <testcase name="testCase6" classname="Tests.Registration" assertions="0" time="3.819" file="tests/registration.code" line="235">
+      <error message="Division by zero." type="ArithmeticError">
+      </error>
+    </testcase>
+    <testcase name="testCase7" classname="Tests.Registration" assertions="3" time="2.944" file="tests/registration.code" line="287">
+      <system-out>Data written to standard out.</system-out>
+      <system-err>Data written to standard error.</system-err>
+    </testcase>
+    <testcase name="testCase8" classname="Tests.Registration" assertions="4" time="1.625275" file="tests/registration.code" line="302">
+      <properties>
+        <property name="priority" value="high" />
+        <property name="language" value="english" />
+        <property name="author" value="Adrian" />
+        <property name="attachment" value="screenshots/dashboard.png" />
+        <property name="attachment" value="screenshots/users.png" />
+        <property name="description">
+          This text describes the purpose of this test case and provides
+          an overview of what the test does and how it works.
+        </property>
+      </properties>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## Summary
- JUnit XML parserを拡張し、failure/error/skippedや各種属性を解析
- 解析結果を詳細表示で確認できるようUIを改善
- 全スキーマを含むサンプルXMLを追加しテストを拡充

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684e04d2e02c8329aa0e3f25da9dc4df